### PR TITLE
MANTA-5342: mako_rollup should survive reprovisioning

### DIFF
--- a/bin/upload_mako_ls.sh
+++ b/bin/upload_mako_ls.sh
@@ -6,14 +6,14 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 export PATH=/opt/local/bin:$PATH
 
 PID=$$
 PID_FILE=/tmp/upload_mako_ls.pid
-OUT_DIR=/var/tmp/mako_rollup
+OUT_DIR=/manta/mako_rollup
 START_TIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 function fatal {


### PR DESCRIPTION
See also https://github.com/joyent/mako-gc-cmon-plugins/pull/1

Additionally, zones should be hot patched with the following

```
manta-oneach -s storage '
  mkdir -p /manta/mako_rollup
  rsync -a /var/tmp/mako_rollup/ /manta/mako_rollup/
  rm -rf /var/tmp/mako_rollup
  ln -s ../../manta/mako_rollup/ /var/tmp/mako_rollup
'
```